### PR TITLE
Fix: setListID pagination was broken

### DIFF
--- a/src/M5StackSAM.cpp
+++ b/src/M5StackSAM.cpp
@@ -61,6 +61,7 @@ void M5SAM::setListID(byte idx) {
   if(idx< list_page * M5SAM_LIST_PAGE_LABELS + list_lines){
     list_idx = idx;
   }
+  list_page = list_idx / M5SAM_LIST_PAGE_LABELS;
 }
 
 String M5SAM::getListString(){


### PR DESCRIPTION
this avoids having to implement a prevList() and fixes the index problem when list_idx > M5SAM_LIST_PAGE_LABELS

